### PR TITLE
Fixed compilation on RPi boards

### DIFF
--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -787,7 +787,7 @@ color: rgb(255, 255, 255);</string>
                      </color>
                     </brush>
                    </colorrole>
-                   <colorrole role="PlaceholderText">
+                   <colorrole role="Base">
                     <brush brushstyle="NoBrush">
                      <color alpha="128">
                       <red>255</red>
@@ -861,7 +861,7 @@ color: rgb(255, 255, 255);</string>
                      </color>
                     </brush>
                    </colorrole>
-                   <colorrole role="PlaceholderText">
+                   <colorrole role="Base">
                     <brush brushstyle="NoBrush">
                      <color alpha="128">
                       <red>255</red>
@@ -935,7 +935,7 @@ color: rgb(255, 255, 255);</string>
                      </color>
                     </brush>
                    </colorrole>
-                   <colorrole role="PlaceholderText">
+                   <colorrole role="Base">
                     <brush brushstyle="NoBrush">
                      <color alpha="128">
                       <red>255</red>
@@ -1061,7 +1061,7 @@ color: rgb(255, 255, 255);</string>
                      </color>
                     </brush>
                    </colorrole>
-                   <colorrole role="PlaceholderText">
+                   <colorrole role="Base">
                     <brush brushstyle="NoBrush">
                      <color alpha="128">
                       <red>255</red>
@@ -1135,7 +1135,7 @@ color: rgb(255, 255, 255);</string>
                      </color>
                     </brush>
                    </colorrole>
-                   <colorrole role="PlaceholderText">
+                   <colorrole role="Base">
                     <brush brushstyle="NoBrush">
                      <color alpha="128">
                       <red>255</red>
@@ -1209,7 +1209,7 @@ color: rgb(255, 255, 255);</string>
                      </color>
                     </brush>
                    </colorrole>
-                   <colorrole role="PlaceholderText">
+                   <colorrole role="Base">
                     <brush brushstyle="NoBrush">
                      <color alpha="128">
                       <red>255</red>

--- a/src/qt/forms/rpcconsolesettings.ui
+++ b/src/qt/forms/rpcconsolesettings.ui
@@ -787,7 +787,7 @@ color: rgb(255, 255, 255);</string>
                      </color>
                     </brush>
                    </colorrole>
-                   <colorrole role="PlaceholderText">
+                   <colorrole role="Base">
                     <brush brushstyle="NoBrush">
                      <color alpha="128">
                       <red>255</red>
@@ -861,7 +861,7 @@ color: rgb(255, 255, 255);</string>
                      </color>
                     </brush>
                    </colorrole>
-                   <colorrole role="PlaceholderText">
+                   <colorrole role="Base">
                     <brush brushstyle="NoBrush">
                      <color alpha="128">
                       <red>255</red>
@@ -935,7 +935,7 @@ color: rgb(255, 255, 255);</string>
                      </color>
                     </brush>
                    </colorrole>
-                   <colorrole role="PlaceholderText">
+                   <colorrole role="Base">
                     <brush brushstyle="NoBrush">
                      <color alpha="128">
                       <red>255</red>
@@ -1061,7 +1061,7 @@ color: rgb(255, 255, 255);</string>
                      </color>
                     </brush>
                    </colorrole>
-                   <colorrole role="PlaceholderText">
+                   <colorrole role="Base">
                     <brush brushstyle="NoBrush">
                      <color alpha="128">
                       <red>255</red>
@@ -1135,7 +1135,7 @@ color: rgb(255, 255, 255);</string>
                      </color>
                     </brush>
                    </colorrole>
-                   <colorrole role="PlaceholderText">
+                   <colorrole role="Base">
                     <brush brushstyle="NoBrush">
                      <color alpha="128">
                       <red>255</red>
@@ -1209,7 +1209,7 @@ color: rgb(255, 255, 255);</string>
                      </color>
                     </brush>
                    </colorrole>
-                   <colorrole role="PlaceholderText">
+                   <colorrole role="Base">
                     <brush brushstyle="NoBrush">
                      <color alpha="128">
                       <red>255</red>

--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -107,7 +107,7 @@ color: rgb(255, 255, 255);</string>
           </color>
          </brush>
         </colorrole>
-        <colorrole role="PlaceholderText">
+        <colorrole role="Base">
          <brush brushstyle="NoBrush">
           <color alpha="128">
            <red>255</red>
@@ -199,7 +199,7 @@ color: rgb(255, 255, 255);</string>
           </color>
          </brush>
         </colorrole>
-        <colorrole role="PlaceholderText">
+        <colorrole role="Base">
          <brush brushstyle="NoBrush">
           <color alpha="128">
            <red>255</red>
@@ -291,7 +291,7 @@ color: rgb(255, 255, 255);</string>
           </color>
          </brush>
         </colorrole>
-        <colorrole role="PlaceholderText">
+        <colorrole role="Base">
          <brush brushstyle="NoBrush">
           <color alpha="128">
            <red>255</red>


### PR DESCRIPTION
This fix works normally on QT framework, so it does not break compilation on x86_64 Linux distros or Windows. It's the official QT 5.10 bug. Which puts "PlaceholderText" instead of "Base". 